### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/org.adishatz.syncpasswd.json
+++ b/org.adishatz.syncpasswd.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.adishatz.syncpasswd",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.